### PR TITLE
use logging instead of print

### DIFF
--- a/templates/genie.yaml
+++ b/templates/genie.yaml
@@ -123,23 +123,28 @@ Resources:
         ZipFile: |
           from __future__ import print_function
           import json
+          import logging
           import os
           import boto3
+          from botocore.exceptions import ClientError
 
-          batch = boto3.client('batch')
+          logger = logging.getLogger()
+          logger.setLevel(logging.DEBUG)
+
           def lambda_handler(event, context):
+              batch = boto3.client('batch')
               # Log the received event
-              print("Received event: " + json.dumps(event, indent=2))
+              logger.debug("Received event: " + json.dumps(event, indent=2))
+
               # Get parameters for the SubmitJob call
               # http://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html
-
               # These should be passed in via Lambda Environment Variables
               try:
                   jobName = os.environ['JOB_NAME']
                   jobQueue = os.environ['JOB_QUEUE']
                   jobDefinition = os.environ['JOB_DEFINITION']
               except (KeyError, ValueError, Exception) as e:
-                  print(e.response['Error']['Message'])
+                  logger.error(e.response['Error']['Message'])
 
               # containerOverrides and parameters are optional
               if event.get('containerOverrides'):
@@ -156,17 +161,15 @@ Resources:
                   response = batch.submit_job(jobQueue=jobQueue, jobName=jobName, jobDefinition=jobDefinition,
                                               containerOverrides=containerOverrides, parameters=parameters)
                   # Log response from AWS Batch
-                  print("Response: " + json.dumps(response, indent=2))
+                  logger.debug("Response: " + json.dumps(response, indent=2))
                   # Return the jobId
                   jobId = response['jobId']
                   return {
                       'jobId': jobId
                   }
-              except Exception as e:
-                  print(e)
-                  message = 'Error submitting Batch Job'
-                  print(message)
-                  raise Exception(message)
+              except ClientError as e:
+                  logger.error(e.response['Error']['Message'])
+
   PeriodicEvent:
     Type: AWS::Events::Rule
     Properties:


### PR DESCRIPTION
Using the python logging library provides more flexibility than
using print statements.