### PR TITLE
update genie parameters

### DIFF
--- a/templates/genie.yaml
+++ b/templates/genie.yaml
@@ -6,11 +6,9 @@ Parameters:
   ComputeImageId:
     Description: The Genie compute resource image ID
     Type: 'AWS::EC2::Image::Id'
-    Default: 'ami-283da057'
   ContainerImage:
     Description: The Genie docker container image
     Type: String
-    Default: 'sagebionetworks/genie:validation1.1.0'
 
 Resources:
   BatchServiceRole:


### PR DESCRIPTION
This makes it so that ComputeImageId and ContainerImage genie
parameters are required.  This means that values must be
set for these parameters otherwise this cloudformation will fail
to deploy.  Having default parameters for these parameters makes
it a little more confusing.