### PR TITLE
Fix genie batch configuration

### DIFF
--- a/templates/genie.yaml
+++ b/templates/genie.yaml
@@ -25,12 +25,26 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Path: "/"
+  BatchInstanceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: "/"
   BatchInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       Path: "/"
       Roles:
-        - !Ref BatchServiceRole
+        - !Ref BatchInstanceRole
   BatchComputeEnvironment:
     Type: "AWS::Batch::ComputeEnvironment"
     Properties:


### PR DESCRIPTION
AWS batch requires a separate instance role[1] to run ECS container
agents.

[1] https://docs.aws.amazon.com/batch/latest/userguide/instance_IAM_role.html