### PR TITLE
Create user for MSSM to transfer files

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -112,6 +112,18 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
+  # temporary user for MSSM to transfer files to Sage.
+  # console access is disabled, api key to allow access to MSSM bucket
+  AWSIAMMssmUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      UserName: mssm@sagebase.org
+      Groups:
+        - !Ref AWSIAMAllUsersGroup
+  AWSIAMMssmUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref AWSIAMMssmUser
   AWSIAMDeveloperUsersGroup:
     Type: 'AWS::IAM::Group'
     Properties:
@@ -307,3 +319,11 @@ Outputs:
     Value: !Ref AWSIAMEnforceMfaPolicy
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-EnforceMfaPolicy'
+  AWSIAMMssmUserAccessKey:
+    Value: !Ref AWSIAMMssmUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-MssmUserAccessKey'
+  AWSIAMMssmSecretUserAccessKey:
+    Value: !GetAtt AWSIAMMssmUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-MssmUserSecretAccessKey'


### PR DESCRIPTION
Our collaborators at MSSM do not want to create an AWS account for
us to setup cross account access for them to access one of our buckets
so they can transfer files to Sage.

After further discussion with MSSM we've decided to provide MSSM
with an Sage IAM account user access key with access to the bucket:

Workflow:
1. Create a new bucket, i.e. `mssm-transfer`
2. Create a new IAM account, i.e. `mssm` user.
3. Create an API access key for mssm user.
4. Setup a restrictive policy to only allow mssm user to access mssm-transfer
   bucket and nothing else.
5. Send the API access key secrets to MSSM using the Signal messenger app.
6. Give MSSM a time window to transfer files.
7. Deactive/delete the mssm user API key after the time window has expired.
8. We handle data transfer from mssm-transer bucket to the bucket that has
   the rest of their data.