### PR TITLE
Deploy service linked roles

### DIFF
--- a/config/prod/service-linked-roles.yaml
+++ b/config/prod/service-linked-roles.yaml
@@ -1,0 +1,7 @@
+template_path: remote/service-linked-roles.yaml
+stack_name: service-linked-roles
+dependencies:
+  - prod/bootstrap.yaml
+hooks:
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"


### PR DESCRIPTION
Setup service linked role to provision EC2 spot instances.

This depends on PR https://github.com/Sage-Bionetworks/aws-infra/pull/161