### PR TITLE
setup a s3 gateway vpc endpoint

### DIFF
--- a/config/prod/s3-gateway-vpc-endpoint.yaml
+++ b/config/prod/s3-gateway-vpc-endpoint.yaml
@@ -1,0 +1,10 @@
+template_path: gateway-vpc-endpoint.yaml
+stack_name: s3-gateway-vpc-endpoint
+dependencies:
+  - prod/sandcastlevpc.yaml
+parameters:
+  VpcName: sandcastlevpc
+  ServiceName: com.amazonaws.us-east-1.s3
+hooks:
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"


### PR DESCRIPTION
Setup a gateway vpc endpoint so that EC2 instances can directly access
other resources in the same VPC (s3, db, dynamo, etc..) instead of
having to go out to the internet to access the same resources.
This will reduce latency and cost since an EC2 doesn't need to go
out thru the NAT gateway.

This depends PR https://github.com/Sage-Bionetworks/aws-infra/pull/171