### PR TITLE
setup ec2 launch role

### DIFF
--- a/config/prod/sc-ec2vpc-launchrole.yaml
+++ b/config/prod/sc-ec2vpc-launchrole.yaml
@@ -1,0 +1,7 @@
+template_path: "remote/sc-ec2vpc-launchrole.yaml"
+stack_name: "sc-ec2vpc-launchrole"
+dependencies:
+  - "prod/essentials.yaml"
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/iam/sc-ec2vpc-launchrole.yaml --create-dirs -o templates/remote/sc-ec2vpc-launchrole.yaml"


### PR DESCRIPTION
Setup an ec2 launch role to allow testing of
SC service actions.  This same deal is already
setup on Scipoolprod account.