### PR TITLE
[SC-26] install SC EC2 actions

### DIFF
--- a/config/prod/sc-ec2-actions.yaml
+++ b/config/prod/sc-ec2-actions.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-ec2-actions.yaml"
+stack_name: "sc-ec2-actions"
+dependencies:
+  - "prod/sc-enduser-iam.yaml"
+  - "prod/cfn-sc-actions-provider.yaml"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+parameters:
+  AssumeRole: "arn:aws:iam::563295687221:role/SCEC2LaunchRole"
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/scipoolprod-sc-lib-infra/master/ec2/sc-ec2-actions.yaml --create-dirs -o templates/remote/sc-ec2-actions.yaml"


### PR DESCRIPTION
Install service catalog EC2 actions to allow users to start,
stop and restat instances. This PR depends on PR https://github.com/Sage-Bionetworks/scipoolprod-sc-lib-infra/pull/107