### PR TITLE
Revert "Give AWS developers users access to batch (#145)"

### DIFF
--- a/templates/jumpcloud-idp.yaml
+++ b/templates/jumpcloud-idp.yaml
@@ -48,7 +48,6 @@ Resources:
       RoleName: !GetAtt SandboxDeveloperSamlProvider.Name
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
-        - arn:aws:iam::aws:policy/AWSBatchFullAccess
         - 'Fn::ImportValue': !Sub '${AWS::Region}-iam-policies-CapacityReservationPolicyArn'
         - 'Fn::ImportValue': !Sub '${AWS::Region}-iam-policies-ViewReportsPolicyArn'
       AssumeRolePolicyDocument:


### PR DESCRIPTION
This reverts commit bbe03ff123004a5fbc605c1a0196ae3fa0519db8.
The power user policy already provides full access to batch