### PR TITLE
Remove IAM user

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -69,13 +69,6 @@ Resources:
       Groups:
         - !Ref AWSIAMAllUsersGroup
         - !Ref AWSIAMDeveloperUsersGroup
-  AWSIAMBrianWhiteUser:
-    Type: 'AWS::IAM::User'
-    Properties:
-      UserName: brian.white@sagebase.org
-      Groups:
-        - !Ref AWSIAMAllUsersGroup
-        - !Ref AWSIAMDeveloperUsersGroup
   AWSIAMMichaelMasonUser:
     Type: 'AWS::IAM::User'
     Properties:


### PR DESCRIPTION
Removing user as part of offboarding... We actually cannot remove all resources in the account, yet, so we should hold off on merging until resources are no longer needed.

Depends on https://github.com/Sage-Bionetworks/sandbox-provisioner/pull/372